### PR TITLE
Implemented ::setcurstat Admin Command

### DIFF
--- a/server/plugins/com/openrsc/server/plugins/commands/Admins.java
+++ b/server/plugins/com/openrsc/server/plugins/commands/Admins.java
@@ -1868,5 +1868,44 @@ public final class Admins implements CommandListener {
 
 			player.message(messagePrefix + Server.getPlayerDataProcessor().getDatabase().banPlayer(usernameToBan, time));
 		}
+		else if(cmd.equalsIgnoreCase("setcurstat")) {
+			if (args.length < 3) {
+				player.message(badSyntaxPrefix + cmd.toUpperCase() + " [player_name] [statID] [level]");
+				return;
+			}
+
+			boolean playerFound = false;
+			for(Player p : World.getWorld().getPlayers()) {
+				if(DataConversions.usernameToHash(args[0]) == DataConversions.usernameToHash(p.getUsername())) {
+					playerFound = true;
+					continue;
+				}
+			}
+
+			if(!playerFound) {
+				player.message("Unable to locate player: " + args[0]);
+				return;
+			}
+
+			if(Integer.parseInt(args[1])< 0 || Integer.parseInt(args[1]) > 17) {
+				player.message("Invalid skill ID. Skill IDs are 0-17 (18 skills)");
+				return;
+			}
+
+			Player p = World.getWorld().getPlayer(DataConversions.usernameToHash(args[0]));
+			int skillID = Integer.parseInt(args[1]);
+			int newCurrentLevel = Integer.parseInt(args[2]);
+
+			player.message("=== ::setcurstat args ===");
+			player.message("Username: " + p.getUsername().toString());
+			player.message("Skill: " + Skills.SKILL_NAME[skillID]);
+			player.message("Set to current level: " + newCurrentLevel);
+
+			p.getSkills().setLevel(skillID, newCurrentLevel);
+
+			if(DataConversions.usernameToHash(player.getUsername()) != DataConversions.usernameToHash(p.getUsername())) {
+				p.message(player.getUsername() + " set you effective " + Skills.SKILL_NAME[skillID] + " level to " + newCurrentLevel);
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR aims to resolve open issue #1527

Usage - ::setcurstat [player] [skill_id] [level]

This allows an admin to set the current effective level of any stat for any player including him/her self.

Command cancelled if the player is not found within the world at time of execution.

Command is cancelled if the admin tries to modify an invalid/non-existent skill.

EDIT: As per Kenix, this should also take the skill as a string and not just the skill ID... That behavior is not currently supported with this code.