### PR TITLE
Fixes

### DIFF
--- a/server/plugins/com/openrsc/server/plugins/authentic/defaults/Default.java
+++ b/server/plugins/com/openrsc/server/plugins/authentic/defaults/Default.java
@@ -197,7 +197,9 @@ public class Default implements DefaultHandler,
 		player.getWorld().getServer().getGameLogger().addQuery(new GenericLog(player.getWorld(), player.getUsername() + " dropped " + item.getDef(player.getWorld()).getName() + " x"
 			+ DataConversions.numberFormat(groundItem.getAmount()) + " at " + player.getLocation().toString()));
 
-		if (totalToDrop > 1) {
+		// Display the Dropping x/y message only if we want batching,
+		// we're dropping more than one item, and the item isn't a stack.
+		if (config().BATCH_PROGRESSION && totalToDrop > 1 && removingThisIteration == 1) {
 			player.message("Dropping " + (totalToDrop - amountToDrop) + "/" + totalToDrop
 				+ " " + player.getWorld().getServer().getEntityHandler().getItemDef(item.getCatalogId()).getName());
 		}

--- a/server/plugins/com/openrsc/server/plugins/authentic/skills/mining/Mining.java
+++ b/server/plugins/com/openrsc/server/plugins/authentic/skills/mining/Mining.java
@@ -216,10 +216,6 @@ public final class Mining implements OpLocTrigger {
 		player.playerServerMessage(MessageType.QUEST, "You swing your pick at the rock...");
 		delay(3);
 
-		if (ifbeginningbatch()) {
-			delay(); // work around b/c for some reason it doesn't actually delay 3 ticks the first time
-		}
-
 		final Item ore = new Item(def.getOreId());
 		if (config().WANT_FATIGUE) {
 			if (config().STOP_SKILLING_FATIGUED >= 1

--- a/server/src/com/openrsc/server/net/rsc/handlers/GroundItemTake.java
+++ b/server/src/com/openrsc/server/net/rsc/handlers/GroundItemTake.java
@@ -3,7 +3,6 @@ package com.openrsc.server.net.rsc.handlers;
 import com.openrsc.server.constants.IronmanMode;
 import com.openrsc.server.model.PathValidation;
 import com.openrsc.server.model.Point;
-import com.openrsc.server.model.action.WalkToPointAction;
 import com.openrsc.server.model.entity.GroundItem;
 import com.openrsc.server.model.entity.player.Player;
 import com.openrsc.server.net.Packet;
@@ -48,35 +47,32 @@ public class GroundItemTake implements PacketHandler {
 		if (PathValidation.isMobBlocking(player, location.getX(), location.getY())) {
 			distance = 1;
 		}
-		player.setWalkToAction(new WalkToPointAction(player, item.getLocation(), distance) {
-			public void executeInternal() {
-				if (getPlayer().isBusy() || getPlayer().isRanging() || item == null || item.isRemoved()
-					|| getPlayer().getRegion().getItem(itemId, getLocation(), getPlayer()) == null || !getPlayer().canReach(item)
-					|| item.getAmount() < 1) {
-					return;
-				}
 
-				if (item.getDef().isMembersOnly() && !getPlayer().getConfig().MEMBER_WORLD) {
-					getPlayer().sendMemberErrorMessage();
-					return;
-				}
-				if (item.getLocation().inWilderness() && !item.belongsTo(getPlayer()) && item.getAttribute("playerKill", false)
-					&& (getPlayer().isIronMan(IronmanMode.Ironman.id()) || getPlayer().isIronMan(IronmanMode.Ultimate.id())
-					|| getPlayer().isIronMan(IronmanMode.Hardcore.id()) || getPlayer().isIronMan(IronmanMode.Transfer.id()))) {
-					getPlayer().message("You're an Iron Man, so you can't loot items from players.");
-					return;
-				}
-				if (!item.belongsTo(getPlayer())
-					&& (getPlayer().isIronMan(IronmanMode.Ironman.id()) || getPlayer().isIronMan(IronmanMode.Ultimate.id())
-					|| getPlayer().isIronMan(IronmanMode.Hardcore.id()) || getPlayer().isIronMan(IronmanMode.Transfer.id()))) {
-					getPlayer().message("You're an Iron Man, so you can't take items that other players have dropped.");
-					return;
-				}
+		if (player.isBusy() || player.isRanging() || item == null || item.isRemoved()
+			|| player.getRegion().getItem(itemId, location, player) == null || !player.canReach(item)
+			|| item.getAmount() < 1) {
+			return;
+		}
 
-				getPlayer().resetAll();
+		if (item.getDef().isMembersOnly() && !player.getConfig().MEMBER_WORLD) {
+			player.sendMemberErrorMessage();
+			return;
+		}
+		if (item.getLocation().inWilderness() && !item.belongsTo(player) && item.getAttribute("playerKill", false)
+			&& (player.isIronMan(IronmanMode.Ironman.id()) || player.isIronMan(IronmanMode.Ultimate.id())
+			|| player.isIronMan(IronmanMode.Hardcore.id()) || player.isIronMan(IronmanMode.Transfer.id()))) {
+			player.message("You're an Iron Man, so you can't loot items from players.");
+			return;
+		}
+		if (!item.belongsTo(player)
+			&& (player.isIronMan(IronmanMode.Ironman.id()) || player.isIronMan(IronmanMode.Ultimate.id())
+			|| player.isIronMan(IronmanMode.Hardcore.id()) || player.isIronMan(IronmanMode.Transfer.id()))) {
+			player.message("You're an Iron Man, so you can't take items that other players have dropped.");
+			return;
+		}
 
-				getPlayer().getWorld().getServer().getPluginHandler().handlePlugin(getPlayer(), "TakeObj", new Object[]{getPlayer(), item}, this);
-			}
-		});
+		player.resetAll();
+
+		player.getWorld().getServer().getPluginHandler().handlePlugin(player, "TakeObj", new Object[]{player, item});
 	}
 }

--- a/server/src/com/openrsc/server/net/rsc/handlers/GroundItemTake.java
+++ b/server/src/com/openrsc/server/net/rsc/handlers/GroundItemTake.java
@@ -3,6 +3,7 @@ package com.openrsc.server.net.rsc.handlers;
 import com.openrsc.server.constants.IronmanMode;
 import com.openrsc.server.model.PathValidation;
 import com.openrsc.server.model.Point;
+import com.openrsc.server.model.action.WalkToPointAction;
 import com.openrsc.server.model.entity.GroundItem;
 import com.openrsc.server.model.entity.player.Player;
 import com.openrsc.server.net.Packet;
@@ -47,32 +48,35 @@ public class GroundItemTake implements PacketHandler {
 		if (PathValidation.isMobBlocking(player, location.getX(), location.getY())) {
 			distance = 1;
 		}
+		player.setWalkToAction(new WalkToPointAction(player, item.getLocation(), distance) {
+			public void executeInternal() {
+				if (getPlayer().isBusy() || getPlayer().isRanging() || item == null || item.isRemoved()
+					|| getPlayer().getRegion().getItem(itemId, getLocation(), getPlayer()) == null || !getPlayer().canReach(item)
+					|| item.getAmount() < 1) {
+					return;
+				}
 
-		if (player.isBusy() || player.isRanging() || item == null || item.isRemoved()
-			|| player.getRegion().getItem(itemId, location, player) == null || !player.canReach(item)
-			|| item.getAmount() < 1) {
-			return;
-		}
+				if (item.getDef().isMembersOnly() && !getPlayer().getConfig().MEMBER_WORLD) {
+					getPlayer().sendMemberErrorMessage();
+					return;
+				}
+				if (item.getLocation().inWilderness() && !item.belongsTo(getPlayer()) && item.getAttribute("playerKill", false)
+					&& (getPlayer().isIronMan(IronmanMode.Ironman.id()) || getPlayer().isIronMan(IronmanMode.Ultimate.id())
+					|| getPlayer().isIronMan(IronmanMode.Hardcore.id()) || getPlayer().isIronMan(IronmanMode.Transfer.id()))) {
+					getPlayer().message("You're an Iron Man, so you can't loot items from players.");
+					return;
+				}
+				if (!item.belongsTo(getPlayer())
+					&& (getPlayer().isIronMan(IronmanMode.Ironman.id()) || getPlayer().isIronMan(IronmanMode.Ultimate.id())
+					|| getPlayer().isIronMan(IronmanMode.Hardcore.id()) || getPlayer().isIronMan(IronmanMode.Transfer.id()))) {
+					getPlayer().message("You're an Iron Man, so you can't take items that other players have dropped.");
+					return;
+				}
 
-		if (item.getDef().isMembersOnly() && !player.getConfig().MEMBER_WORLD) {
-			player.sendMemberErrorMessage();
-			return;
-		}
-		if (item.getLocation().inWilderness() && !item.belongsTo(player) && item.getAttribute("playerKill", false)
-			&& (player.isIronMan(IronmanMode.Ironman.id()) || player.isIronMan(IronmanMode.Ultimate.id())
-			|| player.isIronMan(IronmanMode.Hardcore.id()) || player.isIronMan(IronmanMode.Transfer.id()))) {
-			player.message("You're an Iron Man, so you can't loot items from players.");
-			return;
-		}
-		if (!item.belongsTo(player)
-			&& (player.isIronMan(IronmanMode.Ironman.id()) || player.isIronMan(IronmanMode.Ultimate.id())
-			|| player.isIronMan(IronmanMode.Hardcore.id()) || player.isIronMan(IronmanMode.Transfer.id()))) {
-			player.message("You're an Iron Man, so you can't take items that other players have dropped.");
-			return;
-		}
+				getPlayer().resetAll();
 
-		player.resetAll();
-
-		player.getWorld().getServer().getPluginHandler().handlePlugin(player, "TakeObj", new Object[]{player, item});
+				getPlayer().getWorld().getServer().getPluginHandler().handlePlugin(getPlayer(), "TakeObj", new Object[]{getPlayer(), item}, this);
+			}
+		});
 	}
 }

--- a/server/src/com/openrsc/server/net/rsc/handlers/ItemUseOnObject.java
+++ b/server/src/com/openrsc/server/net/rsc/handlers/ItemUseOnObject.java
@@ -133,10 +133,17 @@ public class ItemUseOnObject implements PacketHandler {
 				item = player.getCarriedItems().getEquipment().get(slotID - Inventory.MAX_SIZE);
 			} else
 				item = player.getCarriedItems().getInventory().get(slotID);
-			if (object.getType() == 1 || item == null || item.getItemStatus().getNoted()) { // This
+			if (object.getType() == 1 || item == null) { // This
 				player.setSuspiciousPlayer(true, "null item or object");
 				return;
 			}
+
+			// Players can't use notes on anything
+			if (item.getItemStatus().getNoted())
+			{
+				player.message("Nothing interesting happens");
+			}
+
 			handleObject(player, object.getLocation(), object, item);
 		}
 	}

--- a/server/src/com/openrsc/server/net/rsc/handlers/ItemUseOnObject.java
+++ b/server/src/com/openrsc/server/net/rsc/handlers/ItemUseOnObject.java
@@ -138,7 +138,7 @@ public class ItemUseOnObject implements PacketHandler {
 				return;
 			}
 
-			// Players can't use notes on anything
+			// Currently, using notes on scenery is not supported.
 			if (item.getItemStatus().getNoted())
 			{
 				player.message("Nothing interesting happens");


### PR DESCRIPTION
1. Fixed the "Dropping X/Y" message to not show on authentic configurations or when dropping a stack.
2. Removed the extra tick at the start of mining. I wasn't able to find a reason for it to be there. Every time I counted out mining ticks, the first swing always had one extra tick. An examination of a RSC+ replay confirmed this.
3. Player is no longer marked suspicious for using a note on a Scenery object. Using a note on a Scenery object now displays the message "Nothing interesting happens" to the player.