### PR TITLE
CF-2986 | Remove 'Duel with' option from player menu if member_world …

### DIFF
--- a/Client_Base/src/orsc/mudclient.java
+++ b/Client_Base/src/orsc/mudclient.java
@@ -1275,7 +1275,7 @@ public final class mudclient implements Runnable {
 					this.menuCommon.addCharacterItem(player.serverIndex, levelDelta >= 0 && levelDelta < 5
 							? MenuItemAction.PLAYER_ATTACK_SIMILAR : MenuItemAction.PLAYER_ATTACK_DIVERGENT, "Attack",
 						"@whi@" + name + level);
-				} else {
+				} else if (wantMembers()) {
 					this.menuCommon.addCharacterItem(player.serverIndex, MenuItemAction.PLAYER_DUEL, "Duel with",
 						"@whi@" + name + level);
 				}

--- a/server/src/com/openrsc/server/net/rsc/handlers/PlayerDuelHandler.java
+++ b/server/src/com/openrsc/server/net/rsc/handlers/PlayerDuelHandler.java
@@ -33,6 +33,12 @@ public class PlayerDuelHandler implements PacketHandler {
 			return;
 		}
 
+		if (!player.getWorld().getServer().getConfig().MEMBER_WORLD) {
+			unsetOptions(player);
+			unsetOptions(affectedPlayer);
+			return;
+		}
+
 		if (player.isIronMan(IronmanMode.Ironman.id()) || player.isIronMan(IronmanMode.Ultimate.id())
 			|| player.isIronMan(IronmanMode.Hardcore.id()) || player.isIronMan(IronmanMode.Transfer.id())) {
 			player.message("You are an Iron Man. You stand alone.");


### PR DESCRIPTION
…is false (F2P)

Potential fix for [#2986](https://gitlab.com/open-runescape-classic/core/-/issues/2986). This is my first change to the ORSC codebase, so please review carefully.