### PR TITLE
CF-2989 | Update bankSize property to check MEMBER_WORLD and return 48 if false (F2P). Update bank buttons logic to only draw page numbers if it is a members world. Prevent clicking of page 1/2/3 even when invisible.

### DIFF
--- a/Client_Base/src/com/openrsc/interfaces/misc/BankInterface.java
+++ b/Client_Base/src/com/openrsc/interfaces/misc/BankInterface.java
@@ -12,6 +12,8 @@ import orsc.util.BankUtil;
 
 import java.util.ArrayList;
 
+import static orsc.Config.*;
+
 public class BankInterface {
 	public static mudclient mc;
 
@@ -20,7 +22,7 @@ public class BankInterface {
 	private boolean swapCertMode;
 
 	public int width, height;
-
+	public boolean membersWorld;
 	public Panel bank;
 	ArrayList<BankItem> bankItems;
 
@@ -28,6 +30,7 @@ public class BankInterface {
 		mc = m;
 		width = 408; // WIDTH MODIFIER
 		height = 334; // HEIGHT MODIFIER
+		membersWorld = wantMembers();
 		bank = new Panel(mc.getSurface(), 3);
 		bankItems = new ArrayList<>();
 	}
@@ -90,16 +93,16 @@ public class BankInterface {
 
 				// Select bank page
 			} else if (currentItems.size() > 48 && selectedX >= 50 && selectedX <= 115 &&
-				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146) {
+				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146 && membersWorld) {
 				mouseOverBankPageText = 0; // Select page 1
 			} else if (currentItems.size() > 48 && selectedX >= 115 && selectedX <= 180 &&
-				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146) {
+				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146 && membersWorld) {
 				mouseOverBankPageText = 1; // Select page 2
 			} else if (currentItems.size() > 96 && selectedX >= 180 && selectedX <= 245 &&
-				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146) {
+				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146 && membersWorld) {
 				mouseOverBankPageText = 2; // Select page 3
 			} else if (currentItems.size() > 144 && selectedX >= 245 && selectedX <= 310 &&
-				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146) {
+				selectedY <= 16 && currMouseY > mc.getGameHeight() / 2 - 146 && membersWorld) {
 				mouseOverBankPageText = 3; // Select page 4
 
 			} else { // Close Bank
@@ -237,8 +240,10 @@ public class BankInterface {
 		drawString("Bank", relativeX + 1, relativeY + 10, 1, 0xffffff);
 
 		// Draw Bank Page Buttons
-		drawPageButtons(currMouseX, currMouseY, relativeX, relativeY);
-
+		if (membersWorld) {
+			drawPageButtons(currMouseX, currMouseY, relativeX, relativeY);
+		}
+		
 		// Draw Top Descriptions & Close Button
 		int closeButtonColour = 0xffffff;
 		if (currMouseX > relativeX + 320 && currMouseY >= relativeY + 3 && currMouseX < relativeX + 408 && currMouseY < relativeY + 15)

--- a/Client_Base/src/com/openrsc/interfaces/misc/BankInterface.java
+++ b/Client_Base/src/com/openrsc/interfaces/misc/BankInterface.java
@@ -270,14 +270,18 @@ public class BankInterface {
 	private void drawPageButtons(int currMouseX, int currMouseY, int relativeX, int relativeY) {
 		int pageButtonMargin = 50;
 		int pageButtonColour = 0xffffff;
-		if (mouseOverBankPageText == 0)
-			pageButtonColour = 0xff0000;
-		else if (currMouseX > relativeX + pageButtonMargin && currMouseY >= relativeY + 4
-			&& currMouseX < relativeX + pageButtonMargin + 65 && currMouseY < relativeY + 16)
-			pageButtonColour = 0xffff00;
-		drawString("<page 1>", relativeX + pageButtonMargin, relativeY + 10, 1, pageButtonColour);
-		pageButtonMargin += 65;
+
 		if (currentItems.size() > 48) {
+			// Page 1
+			if (mouseOverBankPageText == 0)
+				pageButtonColour = 0xff0000;
+			else if (currMouseX > relativeX + pageButtonMargin && currMouseY >= relativeY + 4
+				&& currMouseX < relativeX + pageButtonMargin + 65 && currMouseY < relativeY + 16)
+				pageButtonColour = 0xffff00;
+			drawString("<page 1>", relativeX + pageButtonMargin, relativeY + 10, 1, pageButtonColour);
+			pageButtonMargin += 65;
+
+			// Page 2
 			pageButtonColour = 0xffffff;
 			if (mouseOverBankPageText == 1)
 				pageButtonColour = 0xff0000;

--- a/Client_Base/src/orsc/mudclient.java
+++ b/Client_Base/src/orsc/mudclient.java
@@ -1275,7 +1275,7 @@ public final class mudclient implements Runnable {
 					this.menuCommon.addCharacterItem(player.serverIndex, levelDelta >= 0 && levelDelta < 5
 							? MenuItemAction.PLAYER_ATTACK_SIMILAR : MenuItemAction.PLAYER_ATTACK_DIVERGENT, "Attack",
 						"@whi@" + name + level);
-				} else {
+				} else if (wantMembers()) {
 					this.menuCommon.addCharacterItem(player.serverIndex, MenuItemAction.PLAYER_DUEL, "Duel with",
 						"@whi@" + name + level);
 				}

--- a/Client_Base/src/orsc/mudclient.java
+++ b/Client_Base/src/orsc/mudclient.java
@@ -1275,7 +1275,7 @@ public final class mudclient implements Runnable {
 					this.menuCommon.addCharacterItem(player.serverIndex, levelDelta >= 0 && levelDelta < 5
 							? MenuItemAction.PLAYER_ATTACK_SIMILAR : MenuItemAction.PLAYER_ATTACK_DIVERGENT, "Attack",
 						"@whi@" + name + level);
-				} else if (wantMembers()) {
+				} else {
 					this.menuCommon.addCharacterItem(player.serverIndex, MenuItemAction.PLAYER_DUEL, "Duel with",
 						"@whi@" + name + level);
 				}

--- a/server/src/com/openrsc/server/model/entity/player/Player.java
+++ b/server/src/com/openrsc/server/model/entity/player/Player.java
@@ -65,7 +65,7 @@ public final class Player extends Mob {
 	// 1 walked step is +1 activity, 1 5-min warn to move is +25 activity (saved each 30 secs => 2.5 per save)
 	// so everything is multiplied by 2 to avoid decimals
 	private final int KITTEN_ACTIVITY_THRESHOLD = 50;
-	public int bankSize = getConfig().WANT_CUSTOM_BANKS ? ItemId.maxCustom : 192; //Maximum bank items allowed
+	public int bankSize = getWorld().getServer().getConfig().MEMBER_WORLD ? (getConfig().WANT_CUSTOM_BANKS ? ItemId.maxCustom : 192) : 48; //Maximum bank items allowed
 	private int totalLevel = 0;
 	private Queue<PrivateMessage> privateMessageQueue = new LinkedList<PrivateMessage>();
 	private long lastSave = System.currentTimeMillis();

--- a/server/src/com/openrsc/server/net/rsc/ActionSender.java
+++ b/server/src/com/openrsc/server/net/rsc/ActionSender.java
@@ -1516,9 +1516,11 @@ public class ActionSender {
 		if (player.isUsingAuthenticClient()) {
             int itemsInBank = player.getBank().size();
             s.writeByte(itemsInBank > 255 ? (byte)255 : itemsInBank & 0xFF);
-            if (itemsInBank > 192) {
-                sendMessage(player, "Warning: Unable to display all items in bank!");
-            }
+			if ((player.getWorld().getServer().getConfig().MEMBER_WORLD && itemsInBank > 192) ||
+				(!player.getWorld().getServer().getConfig().MEMBER_WORLD && itemsInBank > 48)) {
+				sendMessage(player, "Warning: Unable to display all items in bank!");
+			}
+
             s.writeByte(player.getBankSize() > 255 ? (byte)255 : player.getBankSize() & 0xFF);
             // If bank is filled to page 4 and bank size reports supporting more than 4 pages
             if (itemsInBank > (192 - 48) && player.getBankSize() > 192) {


### PR DESCRIPTION
Tested locally, works fine, confirmed P2P banking functionality still works