### PR TITLE
CF-2988 | Prevent spawning of Thug, Black Unicorn and Red Dragon in F2P

### DIFF
--- a/Client_Base/src/orsc/mudclient.java
+++ b/Client_Base/src/orsc/mudclient.java
@@ -1275,7 +1275,7 @@ public final class mudclient implements Runnable {
 					this.menuCommon.addCharacterItem(player.serverIndex, levelDelta >= 0 && levelDelta < 5
 							? MenuItemAction.PLAYER_ATTACK_SIMILAR : MenuItemAction.PLAYER_ATTACK_DIVERGENT, "Attack",
 						"@whi@" + name + level);
-				} else {
+				} else if (wantMembers()) {
 					this.menuCommon.addCharacterItem(player.serverIndex, MenuItemAction.PLAYER_DUEL, "Duel with",
 						"@whi@" + name + level);
 				}

--- a/Client_Base/src/orsc/mudclient.java
+++ b/Client_Base/src/orsc/mudclient.java
@@ -1275,7 +1275,7 @@ public final class mudclient implements Runnable {
 					this.menuCommon.addCharacterItem(player.serverIndex, levelDelta >= 0 && levelDelta < 5
 							? MenuItemAction.PLAYER_ATTACK_SIMILAR : MenuItemAction.PLAYER_ATTACK_DIVERGENT, "Attack",
 						"@whi@" + name + level);
-				} else if (wantMembers()) {
+				} else {
 					this.menuCommon.addCharacterItem(player.serverIndex, MenuItemAction.PLAYER_DUEL, "Duel with",
 						"@whi@" + name + level);
 				}

--- a/server/src/com/openrsc/server/database/WorldPopulator.java
+++ b/server/src/com/openrsc/server/database/WorldPopulator.java
@@ -89,6 +89,13 @@ public final class WorldPopulator {
 					n = null;
 					continue;
 				}
+
+				// Don't spawn Thug, Black Unicorn or Red Dragon in F2P
+				if ((n.id == 251 || n.id == 296 || n.id == 201) && !getWorld().getServer().getConfig().MEMBER_WORLD) {
+					n = null;
+					continue;
+				}
+
 				// // if(!Point.inWilderness(n.startX, n.startY) && EntityHandler.getNpcDef(n.id).isAttackable() && n.id != 192 && n.id != 35 && n.id != 196 && n.id != 50 && n.id != 70 && n.id != 136 && n.id != 37) {
 				// //	for(int i = 0; i < 1; i++)
 				// //		world.registerNpc(new Npc(n));

--- a/server/src/com/openrsc/server/database/WorldPopulator.java
+++ b/server/src/com/openrsc/server/database/WorldPopulator.java
@@ -90,8 +90,10 @@ public final class WorldPopulator {
 					continue;
 				}
 
-				// Don't spawn Thug, Black Unicorn or Red Dragon in F2P
-				if ((n.id == 251 || n.id == 296 || n.id == 201) && !getWorld().getServer().getConfig().MEMBER_WORLD) {
+				// Don't spawn attackable members NPCs in F2P
+				if (getWorld().getServer().getEntityHandler().getNpcDef(n.id).isMembers() && 
+					getWorld().getServer().getEntityHandler().getNpcDef(n.id).isAttackable() &&
+					!getWorld().getServer().getConfig().MEMBER_WORLD) {
 					n = null;
 					continue;
 				}


### PR DESCRIPTION
Tested locally in Open RSC client. P2P is unaffected. This is admittedly a lazy fix. Perhaps `Formulae.isP2P` should be updated or rewritten so that it returns true for those 3 NPCs? I didn't see a simple way to do that.