### PR TITLE
[BUGFIX] Prevent NPE on WS decode without SSL config

### DIFF
--- a/server/src/com/openrsc/server/net/RSCMultiPortDecoder.java
+++ b/server/src/com/openrsc/server/net/RSCMultiPortDecoder.java
@@ -8,7 +8,6 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
-import io.netty.handler.ssl.OptionalSslHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.AttributeMap;
@@ -52,7 +51,9 @@ public final class RSCMultiPortDecoder extends ByteToMessageDecoder implements A
 	}
 
 	private void addWebHandlerStack(ChannelHandlerContext ctx) {
-		ctx.pipeline().addFirst(new OptionalSslHandler(this.server.getSSLContext()));
+		if (server.getSSLContext() != null) {
+			ctx.pipeline().addFirst(server.getSSLContext().newHandler(ctx.alloc()));
+		}
 		ctx.pipeline().addBefore(Server.rscConnectionHandlerId, "httpcodec", new HttpServerCodec());
 		ctx.pipeline().addBefore(Server.rscConnectionHandlerId, "aggregator", new HttpObjectAggregator(65536));
 		ctx.pipeline().addBefore(Server.rscConnectionHandlerId, "httphandler", new HttpRequestHandler("/"));


### PR DESCRIPTION
Prevents an NPE when decoding a WebSocket request while `ssl.ssl_server_cert_path` and `ssl.ssl_server_key_path` is not configured.

```
rsc-server  |      [java] io.netty.handler.codec.DecoderException: java.lang.NullPointerException: sslContext
rsc-server  |      [java]       at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:472) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:278) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1408) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:930) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:677) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:612) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:529) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:491) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:905) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at com.openrsc.server.util.ServerAwareThreadFactory.lambda$newThread$0(ServerAwareThreadFactory.java:20) ~[core.jar:?]
rsc-server  |      [java]       at java.lang.Thread.run(Thread.java:833) [?:?]
rsc-server  |      [java] Caused by: java.lang.NullPointerException: sslContext
rsc-server  |      [java]       at io.netty.util.internal.ObjectUtil.checkNotNull(ObjectUtil.java:33) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.handler.ssl.OptionalSslHandler.<init>(OptionalSslHandler.java:39) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at com.openrsc.server.net.RSCMultiPortDecoder.addWebHandlerStack(RSCMultiPortDecoder.java:55) ~[core.jar:?]
rsc-server  |      [java]       at com.openrsc.server.net.RSCMultiPortDecoder.decode(RSCMultiPortDecoder.java:36) ~[core.jar:?]
rsc-server  |      [java]       at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:502) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:441) ~[netty-all-4.1.33.Final.jar:4.1.33.Final]
rsc-server  |      [java]       ... 16 more
```